### PR TITLE
What I Did: Fixed the card mobile design

### DIFF
--- a/mobile/app/cardMobile/index.tsx
+++ b/mobile/app/cardMobile/index.tsx
@@ -10,8 +10,8 @@ const CardMobilePage = () => {
         petName="Buddy"
         ownerName="John Doe"
         doctorName="Dr. Smith"
-        appointmentType="vaccine"
-        appointmentStatus={true}
+        appointmentType="vaccine" // can be "first", "return", "checkup", or "vaccine"
+        appointmentStatus={false} // true when the current time is past the appointment time, false otherwise
         />
     </View>
   );

--- a/mobile/src/components/cardMobile.tsx
+++ b/mobile/src/components/cardMobile.tsx
@@ -14,7 +14,7 @@ type CardMobileProps = {
 const CardMobile = (props: CardMobileProps) => {
     return (
         <View
-        className={`flex flex-row justify-between items-center w-[494px] h-[135px] rounded-2xl px-6 py-4 ${
+        className={`flex flex-row justify-between items-center w-[358px] h-[122px] rounded-2xl px-6 py-4 ${
             props.appointmentStatus ? "bg-[rgba(240,240,240,1)]" :
             props.appointmentType === "first" ? "bg-[rgba(191,181,255,1)]" : 
             props.appointmentType === "return" ? "bg-[rgba(255,100,25,0.6)]" :
@@ -30,12 +30,14 @@ const CardMobile = (props: CardMobileProps) => {
                 <Text className="text-[14px] leading-[1.1] font-bold font-sfpro text-[#101010]">{props.date}</Text>
                 <Text className="text-[14px] leading-[1.1] font-bold font-sfpro text-[#101010]">{props.time}</Text>
             </View>
-            <Text className="text-sm font-normal font-sfpro text-black"><strong>{props.petName}</strong>/{props.ownerName}</Text>
-            <Text className="text-sm font-normal font-sfpro text-black">{props.doctorName}</Text>
+            <View className="flex flex-col w-auto h-auto gap-3">
+                <Text className="text-sm font-normal font-sfpro text-black"><strong>{props.petName}</strong>/{props.ownerName}</Text>
+                <Text className="text-sm font-normal font-sfpro text-black">{props.doctorName}</Text>
+            </View>
             <View className="flex flex-col items-center gap-2">
                 <Image
                 source={require('@assets/cat.png')}
-                style={{ width: 69, height: 70, resizeMode: 'contain' }}
+                style={{ width: 57, height: 57, resizeMode: 'contain' }}
                 />
                 <Text className="w-[108px] p-[6px] rounded-[4px] text-center text-xs font-normal font-sfpro text-nowrap text-[rgba(41,41,41,1)] bg-[rgba(255,255,255,0.8)]">
                     {props.appointmentType === "first" && "Primeira Consulta"}


### PR DESCRIPTION
## What I Did:

### Fixed the card mobile design
- The card mobile design was based on the web model not the mobile model;
- Now the **doctor** name is under the **pet/owner** name instead of being to the right;
- The card dimension and pet image were also adjusted correctly;

---
## How to Test:
- Change to `mobile` directory;
- Run `pnpm expo start`;
- Enter `http://localhost:8081/cardMobile` in the browser;
- You should see the adjusted card mobile.